### PR TITLE
Check for no server id instead of checking for id

### DIFF
--- a/src/routes/api/robotServer.js
+++ b/src/routes/api/robotServer.js
@@ -41,7 +41,7 @@ router.post("/get-members", auth({ user: true }), async (req, res) => {
 router.post("/get-member", auth({ user: true }), async (req, res) => {
   const { getMember } = require("../../controllers/members");
   const { server_id } = req.body;
-  if (server_id) return res.send(jsonError("Invalid Server ID"));
+  if (!server_id) return res.send(jsonError("Invalid Server ID"));
   const member = await getMember({
     user_id: req.body.user.id,
     server_id: server_id,


### PR DESCRIPTION
This call kind-of seems not needed if the /robot-server/get-members is being used. Given that it was broken, nothing currently uses it.