### PR TITLE
Fix /api/dev/auth/ POST call missing dependency

### DIFF
--- a/src/routes/api/auth.js
+++ b/src/routes/api/auth.js
@@ -1,5 +1,5 @@
 const router = require("express").Router();
-const { authUser } = require("../../models/user");
+const authUser = require("../../controllers/auth/authUser");
 
 router.get("/", async (req, res) => {
   console.log(req.headers.token);


### PR DESCRIPTION
This method also could be removed in the future, but might be useful in some cases