### PR TITLE
Added support for joystick inputs and fixed minor bug in the /list endpoint

### DIFF
--- a/src/controllers/controls/buildButtons.js
+++ b/src/controllers/controls/buildButtons.js
@@ -44,7 +44,7 @@ module.exports = async (buttons, channel_id, controls_id) => {
           //Dont publish invalid button
           return;
         }
-
+        
         if (button.break) {
           newButton.break = button.break;
           newButtons.push(newButton);
@@ -114,6 +114,10 @@ module.exports = async (buttons, channel_id, controls_id) => {
 
         if (!foundError && button.disabled) {
           newButton.disabled = true;
+        }
+
+        if (button.joystick) {
+          newButton.joystick = button.joystick;
         }
 
         newButtons.push(newButton);

--- a/src/controllers/robotServer.js
+++ b/src/controllers/robotServer.js
@@ -52,6 +52,9 @@ module.exports.getPublicServers = async () => {
   const { getRobotServersWithOwner } = require("../models/robotServer");
   let getServers = await getRobotServersWithOwner();
   let list = [];
+  if (getServers === null) {
+    return list;
+  }
   getServers.forEach((server) => {
     if (server.settings.unlist === true || server.settings.private === true) {
       //do nothing


### PR DESCRIPTION
Added support for joystick inputs to control robots (currently desktop-only).

Also fixed the API endpoint for listing robot servers to not error and cause the React frontend to hang when the robot_servers table is empty. This allows the server to be bootstrapped with an empty database.