### PR TITLE
Add ability to delete server by server name

### DIFF
--- a/src/models/robotServer.js
+++ b/src/models/robotServer.js
@@ -296,7 +296,12 @@ module.exports.deleteRobotServer = async (server_id) => {
   console.log(server_id);
   const db = require("../services/db");
   try {
-    const query = "DELETE FROM robot_servers WHERE server_id =$1";
+    let query;
+    if (query.includes("serv-")) { // assume server ID
+      query = "DELETE FROM robot_servers WHERE server_id =$1";
+    } else { // assume server name
+      query = "DELETE FROM robot_servers WHERE server_name =$1";
+    }
     const result = await db.query(query, [server_id]);
     console.log("Deleted row count: ", result.rowCount);
 


### PR DESCRIPTION
I made it so you can request to delete a robot server from the name. Since names are required to be unique this should be functionally identical to only being able to delete by ID. 

This should make it drastically easier to delete a server if it's not present in Server Mod's `state`. 